### PR TITLE
Fixes for 1.13.0.3

### DIFF
--- a/common/decisions/soul_travel_decision.txt
+++ b/common/decisions/soul_travel_decision.txt
@@ -1,6 +1,8 @@
 soul_travel_decision = {
 	desc = soul_travel_decision_desc
-	picture = "gfx/interface/illustrations/decisions/decision_personal_religious.dds"
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_personal_religious.dds"
+	}
 	selection_tooltip = soul_travel_decision_tooltip
 	
 	major = no

--- a/common/scripted_effects/soul_travel_decision_effect.txt
+++ b/common/scripted_effects/soul_travel_decision_effect.txt
@@ -2931,6 +2931,7 @@ soul_travel_decision_effect = {
 			limit = {
 				root = { has_trait = adventurer }
 			}
+			remove_trait = adventurer_follower
 			add_trait = adventurer
 		}
 		if = {


### PR DESCRIPTION
Merge commit of the following: 

commit e98a6b04a1060c769be4a16bf09732e2f3429132
Author: L00tcifer <you@example.com>
Date:   Tue Oct 1 17:58:21 2024 +0200

    fix(Adventurer Trait): FIX Adventurer trait transfer

    If the player heir has the 'adventurer follower' trait he won't get the

commit 79c4c82f19237f540786ae69cc331f400136612f
Author: L00tcifer <you@example.com>
Date:   Tue Oct 1 17:56:22 2024 +0200

    fix(1.13 Update): FIX picture section

    With the new update pictures have to be referenced in a new way